### PR TITLE
Add GitHub gist uploading

### DIFF
--- a/bin/ccexport
+++ b/bin/ccexport
@@ -49,10 +49,14 @@ OptionParser.new do |parser|
     options[:jsonl] = file
   end
   
+  parser.on("--gist", "Upload exported markdown as a private GitHub Gist (requires gh CLI)") do
+    options[:gist] = true
+  end
+
   parser.on("-s", "--silent", "Silent mode - suppress all output") do
     options[:silent] = true
   end
-  
+
   parser.on("-h", "--help", "Show this help message") do
     puts parser
     exit
@@ -87,7 +91,11 @@ begin
     template_name = options[:template] || 'default'
     ClaudeConversationExporter.generate_preview(preview_target, !options[:no_open], result[:leaf_summaries] || [], template_name, options[:silent])
   end
-  
+
+  if options[:gist] && result[:output_file]
+    ClaudeConversationExporter.upload_gist(result[:output_file], options[:silent])
+  end
+
   exit 0
 rescue StandardError => e
   puts "Error: #{e.message}" unless options[:silent]

--- a/exe/ccexport
+++ b/exe/ccexport
@@ -107,10 +107,14 @@ OptionParser.new do |parser|
     options[:silent] = true
   end
   
+  parser.on("--gist", "Upload exported markdown as a private GitHub Gist (requires gh CLI)") do
+    options[:gist] = true
+  end
+
   parser.on("--skip-dependency-check", "Skip checking for external dependencies") do
     options[:skip_dependency_check] = true
   end
-  
+
   parser.on("-h", "--help", "Show this help message") do
     puts parser
     exit
@@ -148,7 +152,11 @@ begin
     template_name = options[:template] || 'default'
     ClaudeConversationExporter.generate_preview(preview_target, !options[:no_open], result[:leaf_summaries] || [], template_name, options[:silent])
   end
-  
+
+  if options[:gist] && result[:output_file]
+    ClaudeConversationExporter.upload_gist(result[:output_file], options[:silent])
+  end
+
   exit 0
 rescue StandardError => e
   puts "Error: #{e.message}" unless options[:silent]

--- a/lib/claude_conversation_exporter.rb
+++ b/lib/claude_conversation_exporter.rb
@@ -94,6 +94,38 @@ class ClaudeConversationExporter
       html_filename
     end
 
+    def upload_gist(markdown_path, silent = false)
+      output_helper = lambda { |message| puts message unless silent }
+
+      unless system('which gh > /dev/null 2>&1')
+        raise "gh CLI not found. Install it from https://cli.github.com/ and run 'gh auth login'"
+      end
+
+      unless File.exist?(markdown_path)
+        raise "Markdown file not found: #{markdown_path}"
+      end
+
+      filename = File.basename(markdown_path)
+      content = File.read(markdown_path)
+      description = "Claude Code conversation export: #{filename}"
+
+      stdout, stderr, status = Open3.capture3(
+        'gh', 'api', '--method', 'POST', '/gists',
+        '-f', "description=#{description}",
+        '-f', 'public=false',
+        '-f', "files[#{filename}][content]=#{content}"
+      )
+
+      unless status.success?
+        raise "Failed to create gist: #{stderr}"
+      end
+
+      response = JSON.parse(stdout)
+      html_url = response['html_url']
+      output_helper.call "Gist created: #{html_url}"
+      html_url
+    end
+
     def include_prism
       # Prism.js CSS and JavaScript for syntax highlighting
       # MIT License - https://github.com/PrismJS/prism


### PR DESCRIPTION
Addressing https://github.com/marcheiligers/ccexport/issues/6#issuecomment-4322429022

Let the command accept `--gist` argument

gh cli is required to be installed prior this usage.

Example gist: https://gist.github.com/kopyl/59928754e7f135d4e032879cc5b7c7fa

Video demo: https://github.com/user-attachments/assets/53ab00c7-ba60-4e86-a185-05c1734595d4